### PR TITLE
Do not use subtraction for comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function comparator(a, b) {
-  return a - b;
+  return a < b ? -1 : a > b;
 }
 
 /**


### PR DESCRIPTION
Recently have read [Subtraction is not comparison](http://www.tedunangst.com/flak/post/subtraction-is-not-comparison) ([HN conversation](https://news.ycombinator.com/item?id=8797481)), I'm more aware when I see comparison methods using subtraction in them. In this PR, I just updated the comparison method to use a "better" alternative.

It should be said that I couldn't find a suitable test case that failed under the original comparison method so this is less of a functional issue and more of a learning issue. I'd rather fellow developers learn that using a simple subtraction as a comparator may not be the best option under certain edge cases / different languages.

Feel free to close if you don't agree or if you feel it doesn't make sense for this library. Also, feel free to request that I update this PR with updated documentation changes as you deem necessary. Cheers!
