### PR TITLE
fix 'Dependency Status' badge labels/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-url]][daviddm-image]
+#  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url]
 
 > Bubble Sort
 
@@ -70,5 +70,5 @@ MIT © [Addy Osmani](http://addyosmani.com)
 [npm-image]: https://badge.fury.io/js/bubblesort.svg
 [travis-url]: https://travis-ci.org/addyosmani/bubblesort
 [travis-image]: https://travis-ci.org/addyosmani/bubblesort.svg?branch=master
-[daviddm-url]: https://david-dm.org/addyosmani/bubblesort.svg?theme=shields.io
-[daviddm-image]: https://david-dm.org/addyosmani/bubblesort
+[daviddm-url]: https://david-dm.org/addyosmani/bubblesort
+[daviddm-image]: https://david-dm.org/addyosmani/bubblesort.svg?theme=shields.io


### PR DESCRIPTION
While looking at the README markdown, particulary how the badges (npm pkg, travis-ci, dep status) were added, I noticed that the markdown labels/links for the 'Dependency Status' badge were incorrectly labeled and not consistent with the other two badges in the document.  The [daviddm-image] and [daviddm-url] labels were swapped, but the links they pointed to were also swapped, so all worked fine.  However, since this was a little confusing to me initially, I wanted to fix to make the markdown labels/links consistent throughout the document.
